### PR TITLE
Travis testing on older perls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,19 @@
 language: perl
-perl:
-  - "5.28"
-  - "5.26"
-  - "5.24"
-  - "5.22"
-  - "5.20"
-  - "5.18"
-  - "5.16"
-  - "5.14"
-  - "5.12"
-  - "5.10"
+matrix:
+  include:
+  - perl: "5.28"
+  - perl: "5.26"
+  - perl: "5.24"
+  - perl: "5.22"
+  - perl: "5.20"
+    dist: trusty
+  - perl: "5.18"
+    dist: trusty
+  - perl: "5.16"
+    dist: trusty
+  - perl: "5.14"
+    dist: trusty
+  - perl: "5.12"
+    dist: trusty
+  - perl: "5.10"
+    dist: trusty


### PR DESCRIPTION
Otherwise xenial tests using 5.22 for all prior versions.